### PR TITLE
Update org-directory to ~/.deft

### DIFF
--- a/config.el
+++ b/config.el
@@ -28,7 +28,7 @@
 
 ;; If you use `org' and don't want your org files in the default location below,
 ;; change `org-directory'. It must be set before org loads!
-(setq org-directory "~/org/")
+(setq org-directory "~/.deft/")
 
 ;; This determines the style of line numbers in effect. If set to `nil', line
 ;; numbers are disabled. For relative line numbers, set this to `relative'.


### PR DESCRIPTION
This change updates the org-directory from `~/.org` to `~/.deft`.